### PR TITLE
Remove slick and its dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
         "drupal/token": "*",
         "drupal/views_bulk_operations": "*",
         "drush/drush": "^10",
+        "mukurtu/colorbox": "*",
         "mukurtu/masonry": "*",
         "mukurtu/mukurtu-cms": "dev-main",
         "sibyx/phpgpx": "@RC"

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,6 @@
         }
     ],
     "require": {
-        "bower-asset/jquery-mousewheel": "^3.1",
-        "bower-asset/jquery.easing": "^1.3",
-        "bower-asset/slick-carousel": "^1.8",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_pages": "^2.15",
@@ -78,8 +75,6 @@
         "drupal/search_api": "*",
         "drupal/search_api_glossary": "*",
         "drupal/search_api_solr": "^4.3",
-        "drupal/slick": "^2.2",
-        "drupal/slick_entityreference": "^2.0",
         "drupal/token": "*",
         "drupal/views_bulk_operations": "*",
         "drush/drush": "^10",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,18 @@
             }
         },
         {
+            "type": "package",
+            "package": {
+                "name": "mukurtu/colorbox",
+                "version": "1.6.4",
+                "dist": {
+                    "url": "https://github.com/jackmoore/colorbox/archive/master.zip",
+                    "type": "zip"
+                },
+                "type": "drupal-library"
+            }
+        },
+        {
             "type": "vcs",
 	    "url": "https://github.com/MukurtuCMS/Mukurtu-CMS.git"
         }

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "require": {
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
+        "drupal/blazy": "^2.24",
         "drupal/config_pages": "^2.15",
         "drupal/console": "~1.0",
         "drupal/content_browser": "*",

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/blazy": "^2.24",
+        "drupal/colorbox": "^2.0",
         "drupal/config_pages": "^2.15",
         "drupal/console": "~1.0",
         "drupal/content_browser": "*",


### PR DESCRIPTION
This removes slick & slick entity reference modules as well as the jquery easing and mousewheel libraries. 