### PR TITLE
609: Consistently format composer.json to standard 4 spaces.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,31 +17,31 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         },
-	{
-	    "type": "package",
-	    "package": {
+        {
+            "type": "package",
+            "package": {
                 "name": "mukurtu/og",
-		"version": "1.0.0",
-		"type": "drupal-module",
-		"source": {
-                  "url": "https://github.com/zerolab/og.git",
-		  "type": "git",
-		  "reference": "196-redux"
-		}
-	    }
-	},
-            {
-                "type": "package",
-                "package": {
-                    "name": "mukurtu/colorbox",
-                    "version": "1.6.4",
-                    "dist": {
-                        "url": "https://github.com/jackmoore/colorbox/archive/master.zip",
-                        "type": "zip"
-                    },
-                    "type": "drupal-library"
+                "version": "1.0.0",
+                "type": "drupal-module",
+                "source": {
+                    "url": "https://github.com/zerolab/og.git",
+                    "type": "git",
+                    "reference": "196-redux"
                 }
-            },
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "mukurtu/colorbox",
+                "version": "1.6.4",
+                "dist": {
+                    "url": "https://github.com/jackmoore/colorbox/archive/master.zip",
+                    "type": "zip"
+                },
+                "type": "drupal-library"
+            }
+        },
         {
             "type": "package",
             "package": {
@@ -56,7 +56,7 @@
         },
         {
             "type": "vcs",
-	    "url": "https://github.com/MukurtuCMS/Mukurtu-CMS.git"
+            "url": "https://github.com/MukurtuCMS/Mukurtu-CMS.git"
         }
     ],
     "require": {
@@ -67,7 +67,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/ckeditor_config": "^3.4",
         "drupal/ckeditor_iframe": "^2.2",
-	"drupal/colorbox": "2.0.2",
+        "drupal/colorbox": "2.0.2",
         "drupal/config_pages": "^2.15",
         "drupal/console": "~1.0",
         "drupal/content_browser": "*",


### PR DESCRIPTION
Related to https://github.com/MukurtuCMS/Mukurtu-CMS/issues/609

This consistently formats the composer.json file as 4 spaces before making further changes. The composer.json file was already 4 spaces (different from https://github.com/MukurtuCMS/Mukurtu-CMS/pull/613, where it was mostly 2 spaces).