### PR TITLE
529: Update OG to use Drupal.org version. dev version until next release is created.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_source_csv": "^3.5",
         "drupal/migrate_tools": "^6.0",
+        "drupal/og": "dev-1.x",
         "drupal/paragraphs": "*",
         "drupal/pathauto": "*",
         "drupal/redirect": "*",
@@ -118,7 +119,6 @@
         "drush/drush": "^10",
         "mukurtu/masonry": "*",
         "mukurtu/mukurtu-cms": "dev-main",
-        "mukurtu/og": "*",
         "sibyx/phpgpx": "@RC"
     },
     "require-dev": {


### PR DESCRIPTION
Related to https://github.com/MukurtuCMS/Mukurtu-CMS/issues/529

This updates OG from a nearly 2-year-old version to the latest dev version. It should allow us to stop applying a patch and prepare us for Drupal 10 compatibility.